### PR TITLE
Added an alternate way to start the server + explanation

### DIFF
--- a/materials/6-simple-web-application/2-hello-reitit.md
+++ b/materials/6-simple-web-application/2-hello-reitit.md
@@ -218,6 +218,41 @@ you should be seeing something like this:
 ```json
 {"message":"Hello Reitit!"}
 ```
+## Alternative to the above
+
+If for some reason that doesn't work for you, don't worry about it. Here's another way to start your server.
+
+Your core.clj file should look like this:
+
+```clojure
+(ns calculator-api.core
+  (:gen-class))
+
+(defn -main
+  "I don't do a whole lot ... yet."
+  [& args]
+  (println "Hello, World!"))
+```
+
+We want to add our (start) function over here. It's in another file and in another namespace(remember that, always!). To import it over here, we can do just like we did with the dependencies in the last step.
+
+```clojure
+(ns calculator-api.core
+  (:gen-class))
+
+(require '[calculator-api.server.server])
+
+(defn -main
+  "I don't do a whole lot ... yet."
+  [& args]
+  (println "Hello, World!")
+  (calculator-api.server.server/start))
+
+```
+
+So, what did we do here? We imported the namespace we created before, and that allows us to use functions from another namespace in this one. 
+
+## Testing
 
 Testing HTTP calls can be done in browser,
 but after very simple HTTP Get calls we will soon hit a wall with our browser.

--- a/projects/calculator-api/src/calculator_api/core.clj
+++ b/projects/calculator-api/src/calculator_api/core.clj
@@ -1,7 +1,9 @@
 (ns calculator-api.core
   (:gen-class))
 
+(require '[calculator-api.server.server :as calculator-server])
+
 (defn -main
   "I don't do a whole lot ... yet."
   [& args]
-  (println "Hello, World!"))
+  (calculator-server/start))


### PR DESCRIPTION
For some reason I couldn't start the server by running the repl, (in-ns 'calculator-api.server.server) and then running the (start) function. I tried to get some help on stackoverflow, but nothing came from it. Ended up using this as a solution.