### PR TITLE
Update cask installation command.

### DIFF
--- a/materials/1-first-things-first/2-installation.md
+++ b/materials/1-first-things-first/2-installation.md
@@ -72,7 +72,7 @@ That being done you have brew installed on your Mac.
 ```bash
 brew update
 brew tap adoptopenjdk/openjdk
-brew cask install adoptopenjdk8
+brew install --cask homebrew/cask-versions/adoptopenjdk8
 ```
 
 ### Install Clojure on Mac


### PR DESCRIPTION
"brew cask install adoptopenjdk8" was outdated the new command is "brew install --cask homebrew/cask-versions/adoptopenjdk8"